### PR TITLE
Fall back to 'en' when browser's language is unsupported. Fixes #184.

### DIFF
--- a/zm_app/public/javascripts/dnscheck.js
+++ b/zm_app/public/javascripts/dnscheck.js
@@ -27,12 +27,14 @@ dnscheck.factory('customLoader', function ($http, $q, $timeout) {
 dnscheck.config(function($translateProvider) {
 	$translateProvider.useLoader('customLoader');
 	var lang;
-		if (navigator.userLanguage) // Explorer
+		if (navigator.userLanguage) { // Explorer
 			lang = navigator.userLanguage.substring(0, 2);
-		else if (navigator.language) // FF
-			lang = navigator.languages ? navigator.languages[0].substring(0, 2) : (navigator.language.substring(0, 2) || navigator.userLanguage.substring(0, 2));
-		else
+		} else if (navigator.language) { // FF
+			var browserLang = navigator.languages ? navigator.languages[0].substring(0, 2) : (navigator.language.substring(0, 2) || navigator.userLanguage.substring(0, 2));
+			lang = browserLang.match(/(en|fr|sv)/i) ? browserLang : "en";
+		} else {
 			lang = "en";
+		}
 		
 	$translateProvider.preferredLanguage(lang);
 });

--- a/zm_app/public/javascripts/dnscheck.js
+++ b/zm_app/public/javascripts/dnscheck.js
@@ -31,7 +31,7 @@ dnscheck.config(function($translateProvider) {
 			lang = navigator.userLanguage.substring(0, 2);
 		} else if (navigator.language) { // FF
 			var browserLang = navigator.languages ? navigator.languages[0].substring(0, 2) : (navigator.language.substring(0, 2) || navigator.userLanguage.substring(0, 2));
-			lang = browserLang.match(/(en|fr|sv)/i) ? browserLang : "en";
+			lang = browserLang.match(/(en|fr|sv|da)/i) ? browserLang : "en";
 		} else {
 			lang = "en";
 		}


### PR DESCRIPTION
See issue #184.

Hardcoding the language codes in JS is certainly not ideal, but i have not found any config file of other good place to get them from (apart from `Frontend.pm` and `index.tt`, where they are hardcoded, too).

Another way would be to make use of the language switcher (ES6 used for brevity):

```javascript
let supportedLangs = [];
document.querySelectorAll("lang").forEach((lang) => supportedLangs.push(lang.lang));
console.log(supportedLangs);  // -> ["en", "fr", "sv"]
supportedLangs.includes("en") // -> true
supportedLangs.includes("cs") // -> false

// so we can do something like:
lang = supportedLangs.includes(browserLang) ? browserLang : "en";
```
…but i'm not too in favor of querying the DOM just for this.