### PR TITLE
Use root-relative URL for the no-JS interface CSS. Fixes #187.

### DIFF
--- a/zm_app/views/nojs_main_view.tt
+++ b/zm_app/views/nojs_main_view.tt
@@ -2,7 +2,7 @@
 	<head>
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="stylesheet" href="<% request.uri_base %>/css/nojs_style.css" />
+		<link rel="stylesheet" href="/css/nojs_style.css" />
 		<% IF test_running %>
 			<meta http-equiv="refresh" content="5;url=/nojs?test_id=<% test_id %>">
 		<% END %>


### PR DESCRIPTION
See issue #187.

![kookaburra_20170630_175659](https://user-images.githubusercontent.com/178133/27743819-89f6b458-5dbd-11e7-9237-17229a1b7d0d.png)
